### PR TITLE
Added CAD files of rocket (using Git LFS)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.sldprt filter=lfs diff=lfs merge=lfs -text
+*.SLDPRT filter=lfs diff=lfs merge=lfs -text
+*.sldasm filter=lfs diff=lfs merge=lfs -text
+*.SLDASM filter=lfs diff=lfs merge=lfs -text
+*.slddrw filter=lfs diff=lfs merge=lfs -text
+*.SLDDRW filter=lfs diff=lfs merge=lfs -text

--- a/cad/body.SLDPRT
+++ b/cad/body.SLDPRT
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:086deae44d8cc7019c092611e90847831c9b34cd75bc47e5e69cda261be2712c
+size 64655

--- a/cad/drogue_block.SLDPRT
+++ b/cad/drogue_block.SLDPRT
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a46b3a20d1cb418e5ded1e3d184899efb7511990cf0df0de060264834c70e3ac
+size 36793

--- a/cad/hatch.SLDPRT
+++ b/cad/hatch.SLDPRT
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3294eee1ad17efaf2d368f60f77470336f2ec82506a9ff2b05edadcaf348a2af
+size 41455

--- a/cad/nosecone.SLDPRT
+++ b/cad/nosecone.SLDPRT
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8832de9e5d7cf328ef80cece2674cab71bacb18e34f5f863637649e1752fda5b
+size 77904

--- a/cad/parachute_block.SLDPRT
+++ b/cad/parachute_block.SLDPRT
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff521dfc27c2ca6d70629a42f9c3ad389f617173c33feb872a5d73989684b6db
+size 37130

--- a/cad/rocket.SLDASM
+++ b/cad/rocket.SLDASM
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc8d57192a906daf7cb16c86b65b07700318cfdeb1a980fe2ebbccb0c5a89788
+size 67892


### PR DESCRIPTION
Adds the CAD model files in #1, but uses Git LFS to do it. Otherwise, after some time pulling and cloning the repository would become slow and generally, it's best to use LFS for larger binaries like Solidworks files.

Hopefully we don't change these files too much to hit GitHub's bandwidth and storage limits. 